### PR TITLE
Update tag.md

### DIFF
--- a/api/tag.md
+++ b/api/tag.md
@@ -3,8 +3,10 @@
 ## Tag.sprite
 
 ## Tag.fromFrame
+Returns the starting frame number for the tag (not a Frame object).
 
 ## Tag.toFrame
+Returns the ending frame number for the tag (not a Frame object).
 
 ## Tag.frames
 


### PR DESCRIPTION
Clarify that the return type from the Tag.fromFrame property is not a Frame object but simply the frame number (even if this may change).

This tripped me up for a bit so I figured I'd clarify the docs.