### PR TITLE
Fill out missing spots in the app.fs documentation

### DIFF
--- a/api/app_fs.md
+++ b/api/app_fs.md
@@ -111,13 +111,27 @@ Returns `path1/path2` on macOS or Linux, and `path1\path2` on Windows.
 
 ## app.fs.currentPath
 
+Returns the path the Aseprite executable was launched from.
+
 ## app.fs.appPath
+
+Returns the installation path of Aseprite for the current platform.
 
 ## app.fs.tempPath
 
+Returns the path for temporary files for the current platform.
+
+On macOS or Linux it will be `/tmp`, and Windows it will be `%temp%` & look like `C:\Users\username\AppData\Local\Temp\`.
+
 ## app.fs.userDocsPath
 
+Returns the current user's Documents path for the current platform. 
+
+Depending on the platform, this may return the user's home directory.
+
 ## app.fs.userConfigPath
+
+Returns the current user's Aseprite configuration path for the current platform.
 
 # File System Access
 

--- a/api/app_fs.md
+++ b/api/app_fs.md
@@ -10,7 +10,7 @@ A set of function to handle file names and the file system.
 local fn = "path" .. app.fs.pathSeparator .. "filename.png"
 ```
 
-Return sthe preferred path separator of the current platform, it is
+Returns the preferred path separator of the current platform, it is
 `/` on macOS and Linux, and `\` on Windows. Preferably you should use
 [app.fs.joinPath()](#appfsjoinpath).
 
@@ -86,6 +86,16 @@ print(app.fs.fileExtension('path/file.png'))
 Prints `path/file`.
 
 ## app.fs.normalizePath()
+
+Returns the file path converted to a canonical form for the current platform. 
+
+Example:
+
+```lua
+print(app.fs.normalizePath("//home//user//path"))
+```
+
+Will print as `/home/user/path` on macOS and Linux, and `C:\home\user\path` on Windows.
 
 ## app.fs.joinPath()
 

--- a/api/app_fs.md
+++ b/api/app_fs.md
@@ -121,7 +121,7 @@ Returns the installation path of Aseprite for the current platform.
 
 Returns the path for temporary files for the current platform.
 
-On macOS or Linux it will be `/tmp`, and Windows it will be `%temp%` & look like `C:\Users\username\AppData\Local\Temp\`.
+On macOS or Linux it will be `/tmp`, and Windows it will look like `C:\Users\username\AppData\Local\Temp\`.
 
 ## app.fs.userDocsPath
 

--- a/api/app_fs.md
+++ b/api/app_fs.md
@@ -92,28 +92,32 @@ Returns the file path converted to a canonical form for the current platform.
 Example:
 
 ```lua
-print(app.fs.normalizePath("//home//user//path"))
+print(app.fs.normalizePath('//home//user//path'))
 ```
 
 Will print as `/home/user/path` on macOS and Linux, and `C:\home\user\path` on Windows.
 
 ## app.fs.joinPath()
 
+Can accept any number of string arguments to join together with the path separator for the current platform.
+
 ```lua
-local path = app.fs.joinPath(path1, path2)
+local path = app.fs.joinPath('path1', 'path2')
 ```
+
+Returns `path1/path2` on macOS or Linux, and `path1\path2` on Windows.
 
 # Special Folders
 
-## app.currentPath
+## app.fs.currentPath
 
-## app.appPath
+## app.fs.appPath
 
-## app.tempPath
+## app.fs.tempPath
 
-## app.userDocsPath
+## app.fs.userDocsPath
 
-## app.userConfigPath
+## app.fs.userConfigPath
 
 # File System Access
 

--- a/api/app_fs.md
+++ b/api/app_fs.md
@@ -95,7 +95,7 @@ Example:
 print(app.fs.normalizePath('//home//user//path'))
 ```
 
-Will print as `/home/user/path` on macOS and Linux, and `C:\home\user\path` on Windows.
+Will print as `/home/user/path` on macOS or Linux, and `C:\home\user\path` on Windows.
 
 ## app.fs.joinPath()
 


### PR DESCRIPTION
Provides updates to the `app.fs` documentation introduced in Aseprite 1.2.17.

- Fixes typo
- Expands up on documentation for normalizePath() & joinPath()
- Adds in documentation for specialized folders & fixes heading strings to the property value in API.

I'm not 100% on some of my descriptions but figured it was a step in the right direction for others looking to utilize the file system methods.