### PR TITLE
Fix typo in plugin/package.json example.

### DIFF
--- a/api/plugin.md
+++ b/api/plugin.md
@@ -20,7 +20,7 @@ To create a plugin we have to create a folder with a `package.json` file. For ex
   "categories": [ "Scripts" ],
   "contributes": {
     "scripts": [
-        { "path": "./my-script.lua" },
+        { "path": "./my-script.lua" }
     ]
   }
 }


### PR DESCRIPTION
Hey, there is a little typo in the plugin docs!

The following JSON is not valid:
```json
scripts": [
  { "path": "./my-script.lua" },
]
```
It results in the following error in Aseprite:
```
A problem has occurred:

Details:
Error parsing JSON file: expected value got ']' (93)
```