### PR TITLE
Change 'ok' to 'confirm' in dialog.md

### DIFF
--- a/api/dialog.md
+++ b/api/dialog.md
@@ -8,11 +8,11 @@ Example:
 ```lua
 local dlg = Dialog()
 dlg:entry{ id="user_value", label="User Value:", text="Default User" }
-dlg:button{ id="ok", text="OK" }
+dlg:button{ id="confirm", text="Confirm" }
 dlg:button{ id="cancel", text="Cancel" }
 dlg:show()
 local data = dlg.data
-if data.ok then
+if data.confirm then
   app.alert("The given value is '" .. data.user_value .. "'")
 end
 ```
@@ -24,10 +24,10 @@ For example:
 ```lua
 local data =
   Dialog():entry{ id="user_value", label="User Value:", text="Default User" }
-          :button{ id="ok", text="OK" }
+          :button{ id="confirm", text="Confirm" }
           :button{ id="cancel", text="Cancel" }
           :show().data
-if data.ok then
+if data.confirm then
   app.alert("The given value is '" .. data.user_value .. "'")
 end
 ```


### PR DESCRIPTION
Fixes #45 

The id 'ok' of the ok button may be mistaken for a check whether the
dialog data in general is valid (line 15 in dialog.md), rather than a
check whether the field named 'ok' is true. Renaming it to 'confirm'
should make this more clear and is consistent with the id 'cancel' of
the second button on that dialog.