### PR TITLE
Add `onchange` to slider in dialog.md

### DIFF
--- a/api/dialog.md
+++ b/api/dialog.md
@@ -318,7 +318,8 @@ dlg:slider{ id=string,
             label=string,
             min=integer,
             max=integer,
-            value=integer }
+            value=integer
+            onchange=function }
 ```
 
 Creates a slider in the dialog.

--- a/api/dialog.md
+++ b/api/dialog.md
@@ -119,7 +119,8 @@ local dlg = Dialog()
 dlg:combobox{ id=string,
               label=string,
               option=string,
-              options={ string1,string2,string3... } }
+              options={ string1,string2,string3... }
+              onchange=function }
 ```
 
 Creates a combo box/drop-down list.


### PR DESCRIPTION
Fixes #47 

The callback actually exists, but is missing in the documentation.
Figured it out by experimenting.