### PR TITLE
Add documentation for 'ChangePixelFormat' command

### DIFF
--- a/api/app_command.md
+++ b/api/app_command.md
@@ -20,7 +20,7 @@ parameters.
 * `app.command.CelProperties`
 * `app.command.ChangeBrush`
 * `app.command.ChangeColor`
-* `app.command.ChangePixelFormat`
+* [`app.command.ChangePixelFormat`](command/ChangePixelFormat.md#changepixelformat)
 * `app.command.ClearCel`
 * `app.command.Clear`
 * `app.command.CloseAllFiles`

--- a/api/command/ChangePixelFormat.md
+++ b/api/command/ChangePixelFormat.md
@@ -1,0 +1,20 @@
+# ChangePixelFormat
+
+```lua
+app.command.ChangePixelFormat {
+  format=string
+}
+```
+
+Changes the [ColorMode](../colormode.md) of the active [sprite](../sprite.md)
+
+* `format`: Can be `"rgb"`, `"gray"` or `"indexed"`.
+
+## Example
+
+```lua
+app.commandCahngePixelFormat {
+  format="indexed"
+}
+```
+


### PR DESCRIPTION
As it is not obvious what 'ChangePixelFormat' does, this .md file tells
API users how to correctly use the command