### PR TITLE
Layer Documentation Revisions

### DIFF
--- a/api/layer.md
+++ b/api/layer.md
@@ -1,22 +1,8 @@
 # Layer
 
-## Layer.sprite
+Layers are arranged as a stack within a sprite. Layers may nest within each other to form a hierarchy. Layers that accept children are group layers.
 
-Gets the sprite to which this layer belongs.
-
-## Layer.name
-
-Gets/sets the layer name (a string).
-
-## Layer.opacity
-
-```lua
-local opacity = layer.opacity
-layer.opacity = newOpacity
-```
-
-Gets or sets the cel opacity. A value from `0` to `255` (which means
-`0=0%` completely transparent, or `255=100%` completely opaque).
+A layer can be created with [Sprite:newLayer](sprite.md#spritenewlayer). A group layer can be created with [Sprite:newGroup](sprite.md#spritenewgroup). Layers can be removed with [Sprite:deleteLayer](sprite.md#spritedeletelayer).
 
 ## Layer.blendMode
 
@@ -25,93 +11,13 @@ local blendMode = layer.blendMode
 layer.blendMode = newBlendMode
 ```
 
-Gets or sets the layer blending mode. Check the possible
-[BlendMode](blendmode.md#blendmode) values.
-
-## Layer.layers
-
-It's a table of sub-layers if this layer is a group
-([`Layer.isGroup`](#layerisgroup)), or nil if this is not a group.
-
-## Layer.parent
-
-```lua
-local spriteOrLayerGroup = layer.parent
-layer.parent = sprite
-layer.parent = group
-```
-
-Gets the sprite or the layer group which this layer belongs. You can
-also sets the parent to move the layer at the top of the stack of that
-parent.
-
-## Layer.stackIndex
-
-```lua
-local index = layer.stackIndex
-layer.stackIndex = newPosition
-```
-
-Gets or sets the position of this layer in the stack (i.e. the index
-in the `layer.parent.layers` table). `1` means the first layer (the
-[background layer](https://www.aseprite.org/docs/layers/#background-layer)),
-and bigger numbers layers that are above.
-
-## Layer.isImage
-
-It's true if this layer has [cels](cel.md#cel) with [images](image.md#image).
-
-## Layer.isGroup
-
-It's true if this layer has sublayers inside.
-
-## Layer.isTransparent
-
-It's true if this layer is a [transparent layer](https://www.aseprite.org/docs/layers/#transparent-layers)
-(instead of a the [background layer](#layerisbackground)). Transparent layers have
-an alpha channel or, for [indexed color mode](colormode.md#colormodeindexed),
-the [transparent index](https://www.aseprite.org/docs/transparent-color/) is not visible.
-
-## Layer.isBackground
-
-It's true if this layer is the [background layer](https://www.aseprite.org/docs/layers/#background-layer).
-A background layer is opaque, doesn't have alpha channel (`Alpha=255` on every pixel),
-or in [indexed color mode](colormode.md#colormodeindexed), the
-[transparent index](https://www.aseprite.org/docs/transparent-color/) is ignored.
-
-## Layer.isEditable
-
-## Layer.isVisible
-
-```lua
-local visible = layer.isVisible
-layer.isVisible = visible
-```
-
-A boolean property (`true` or `false`) that indicates if the layer is
-visible or hidden. Also can be set to show or hide the layer.
-
-## Layer.isContinuous
-
-## Layer.isCollapsed
-
-## Layer.isExpanded
-
-## Layer.isReference
-
-```lua
-local isRef = layer.isReference
-```
-
-Returns true if the layer is a reference layer. You cannot change the
-value of this property.
+Gets or sets the layer [BlendMode](blendmode.md#blendmode), expressed as an integer or enumerated constant.
 
 ## Layer.cels
 
-Returns the collection of [cels](cel.md#cel) of this layer. Empty if the
-layer is a group.
+Gets a `table` of [cels](cel.md#cel) in the layer. If the layer is a group, this property will return a table of zero length.
 
-See also the [Layer:cel()](#layercel) function.
+See also the [Layer:cel()](#layercel) method.
 
 ## Layer.color
 
@@ -129,7 +35,120 @@ local data = layer.data
 layer.data = data
 ```
 
-Gets or sets the user-defined data related to this layer (a text string).
+Gets or sets the user-defined data related to this layer, a `string`.
+
+## Layer.isBackground
+
+Gets whether or not a layer is a background. The opposite of the property [Layer.isTransparent](#layeristransparent). Background layers do not contain images which support transparency. 
+
+For context, see the general documentation on [layers](https://www.aseprite.org/docs/layers). 
+
+## Layer.isCollapsed
+
+Gets or sets whether or not a [group](#layerisgroup) layer is collapsed, i.e., whether its child layers are hidden in the timeline. The opposite of the property [Layer.isExpanded](#layerisexpanded).
+
+The getter describes only the group layer's local collapse, not whether any hierarchy that contains it is collapsed. See [Layer.isVisible](#layerisvisible) for an example snippet using a similar property.
+
+## Layer.isContinuous
+
+Gets or sets whether a layer biases toward linked [cels](cel.md#cel) when a new cel is created in the timeline.
+
+For context, see the general documentation on [continuous layers](https://www.aseprite.org/docs/continuous-layers/).
+
+## Layer.isEditable
+
+Gets or sets whether a layer is editable, unlocked in other words.
+
+The getter describes only the group layer's local editability, not whether any hierarchy that contains it is editable. See [Layer.isVisible](#layerisvisible) for an example snippet using a similar property.
+
+## Layer.isExpanded
+
+Gets or sets whether or not a [group](#layerisgroup) layer is expanded, meaning whether its child layers are visible in the timeline. The opposite of the property [Layer.isCollapsed](#layeriscollapsed).
+
+The getter describes only the group layer's local expansion, not whether any hierarchy that contains it is expanded. See [Layer.isVisible](#layerisvisible) for an example snippet using a similar property.
+
+## Layer.isGroup
+
+Gets whether or not the layer is a group and *has the capacity* to be a parent to other layers. A layer may be a group, yet have no children; in such a case, its [layers](#layerlayers) property will return a table of zero length.
+
+Groups may nest within groups, creating a hierarchy.
+
+## Layer.isImage
+
+Gets whether or not the layer contains [cels](cel.md#cel) with [images](image.md#image).
+
+## Layer.isReference
+
+```lua
+local isRef = layer.isReference
+```
+
+Gets whether or not the layer is a reference layer.
+
+## Layer.isTransparent
+
+Gets whether or not a layer supports transparency. The opposite of the property [Layer.isBackground](#layerisbackground). For [indexed color mode](colormode.md#colormodeindexed), the layer may contain images with a [transparent color](imagespec.md#imagespectransparentcolor) index. For RGB or grayscale color mode, the layer may contain images with an alpha channel.
+
+For context, see the general documentation on [layers](https://www.aseprite.org/docs/layers).
+
+## Layer.isVisible
+
+Gets or sets whether or not the layer is visible.
+
+```lua
+local sprite = app.activeSprite
+local layerGroup = sprite:newGroup()
+local layers = sprite.layers
+local layer1 = layers[1]
+layer1.parent = layerGroup
+layerGroup.isVisible = false
+layer1.isVisible = true
+print(layer1.isVisible)
+```
+
+The getter describes only the layer's local visibility, not its visibility with respect to any hierarchy that contains it.
+
+## Layer.layers
+
+If a layer is a [group](#layerisgroup), gets the `table` of child layers for which the group serves as a [parent](#layerparent). If the layer is not a group, returns `nil`.
+
+## Layer.name
+
+Gets or sets the layer name, a `string`.
+
+## Layer.opacity
+
+```lua
+local opacity = layer.opacity
+layer.opacity = newOpacity
+```
+
+Gets or sets the layer opacity, a value from `0` to `255`. The layer is completely transparent when the value is `0`; opaque when the value is `255`. When the layer is a [background](#layerisbackground), returns `255`. When the layer is a [group](#layerisgroup), returns `nil`.
+
+## Layer.parent
+
+Gets or sets the layer's parent. The parent may be either a [sprite](sprite.md#sprite) or layer that is a [group](#layerisgroup).
+
+```lua
+local spriteOrLayerGroup = layer.parent
+layer.parent = sprite
+layer.parent = group
+```
+
+Upon setting the parent, the child layer is moved to the top of the parent's layer [stack](#layerstackindex). Throws an error if the parent layer is not a group or if the setter tries to parent a layer to itself.
+
+## Layer.sprite
+
+Gets the [sprite](sprite.md#sprite) to which a layer belongs.
+
+## Layer.stackIndex
+
+```lua
+local index = layer.stackIndex
+layer.stackIndex = newPosition
+```
+
+Gets or sets the layer's index in its parent's layers `table`. In other words, this is the layer's place in the local stack. Layers stack in descending order. For example, a layer with index `1` will lie beneath a layer with index `2`, assuming the layers share the same parent.
 
 ## Layer:cel()
 
@@ -138,5 +157,4 @@ local cel = layer:cel(frameNumber)
 assert(cel == layer:cel(sprite.frames[frameNumber]))
 ```
 
-Returns the [Cel](cel.md#cel) in the given [frame](frame.md#frame) or
-`frameNumber` (an integer). Returns `nil` if there is no cel in the layer/frame.
+Returns a [cel](cel.md#cel), if any, at the intersection of the layer and a frame. The frame may be either a [frame](frame.md#frame) object or its [frame number](frame.md#frameframenumber), an integer. If there is no cel at that intersection, returns `nil`.

--- a/api/layer.md
+++ b/api/layer.md
@@ -11,11 +11,11 @@ local blendMode = layer.blendMode
 layer.blendMode = newBlendMode
 ```
 
-Gets or sets the layer [BlendMode](blendmode.md#blendmode), expressed as an integer or enumerated constant.
+Gets or sets the layer [BlendMode](blendmode.md#blendmode), expressed as an integer or enumerated constant. When the layer is a [group](#layerisgroup), the getter returns `nil`.
 
 ## Layer.cels
 
-Gets a `table` of [cels](cel.md#cel) in the layer. If the layer is a group, this property will return a table of zero length.
+Gets a `table` of [cels](cel.md#cel) in the layer. If the layer is a [group](#layerisgroup), this property will return a table of zero length.
 
 See also the [Layer:cel()](#layercel) method.
 
@@ -39,19 +39,19 @@ Gets or sets the user-defined data related to this layer, a `string`.
 
 ## Layer.isBackground
 
-Gets whether or not a layer is a background. The opposite of the property [Layer.isTransparent](#layeristransparent). Background layers do not contain images which support transparency. 
+Gets whether or not a layer is a background. Returns `false` if the layer is a [group](#layerisgroup). The opposite of the property [Layer.isTransparent](#layeristransparent). Background layers do not contain images which support transparency. 
 
 For context, see the general documentation on [layers](https://www.aseprite.org/docs/layers). 
 
 ## Layer.isCollapsed
 
-Gets or sets whether or not a [group](#layerisgroup) layer is collapsed, i.e., whether its child layers are hidden in the timeline. The opposite of the property [Layer.isExpanded](#layerisexpanded).
+Gets or sets whether or not a [group](#layerisgroup) layer is collapsed, i.e., whether its child layers are hidden in the timeline. Returns `false` if the layer is not a group. The opposite of the property [Layer.isExpanded](#layerisexpanded).
 
 The getter describes only the group layer's local collapse, not whether any hierarchy that contains it is collapsed. See [Layer.isVisible](#layerisvisible) for an example snippet using a similar property.
 
 ## Layer.isContinuous
 
-Gets or sets whether a layer biases toward linked [cels](cel.md#cel) when a new cel is created in the timeline.
+Gets or sets whether a layer biases toward linked [cels](cel.md#cel) when a new cel is created in the timeline. Returns `false` if the layer is a [group](#layerisgroup).
 
 For context, see the general documentation on [continuous layers](https://www.aseprite.org/docs/continuous-layers/).
 
@@ -63,7 +63,7 @@ The getter describes only the group layer's local editability, not whether any h
 
 ## Layer.isExpanded
 
-Gets or sets whether or not a [group](#layerisgroup) layer is expanded, meaning whether its child layers are visible in the timeline. The opposite of the property [Layer.isCollapsed](#layeriscollapsed).
+Gets or sets whether or not a [group](#layerisgroup) layer is expanded, meaning whether its child layers are visible in the timeline. Returns `true` if the layer is not a group. The opposite of the property [Layer.isCollapsed](#layeriscollapsed).
 
 The getter describes only the group layer's local expansion, not whether any hierarchy that contains it is expanded. See [Layer.isVisible](#layerisvisible) for an example snippet using a similar property.
 
@@ -87,7 +87,9 @@ Gets whether or not the layer is a reference layer.
 
 ## Layer.isTransparent
 
-Gets whether or not a layer supports transparency. The opposite of the property [Layer.isBackground](#layerisbackground). For [indexed color mode](colormode.md#colormodeindexed), the layer may contain images with a [transparent color](imagespec.md#imagespectransparentcolor) index. For RGB or grayscale color mode, the layer may contain images with an alpha channel.
+Gets whether or not a layer supports transparency. Returns `true` if the layer is a group. The opposite of the property [Layer.isBackground](#layerisbackground).
+
+For [indexed color mode](colormode.md#colormodeindexed), the layer may contain images with a [transparent color](imagespec.md#imagespectransparentcolor) index. For RGB or grayscale color mode, the layer may contain images with an alpha channel.
 
 For context, see the general documentation on [layers](https://www.aseprite.org/docs/layers).
 
@@ -106,7 +108,7 @@ layer1.isVisible = true
 print(layer1.isVisible)
 ```
 
-The getter describes only the layer's local visibility, not its visibility with respect to any hierarchy that contains it.
+The getter describes only the layer's local visibility, not its visibility with respect to a hierarchy that may contain it.
 
 ## Layer.layers
 
@@ -127,7 +129,7 @@ Gets or sets the layer opacity, a value from `0` to `255`. The layer is complete
 
 ## Layer.parent
 
-Gets or sets the layer's parent. The parent may be either a [sprite](sprite.md#sprite) or layer that is a [group](#layerisgroup).
+Gets or sets the layer's parent. The parent may be either a [sprite](sprite.md#sprite) or a [group](#layerisgroup) layer.
 
 ```lua
 local spriteOrLayerGroup = layer.parent


### PR DESCRIPTION
Added top-level description to layers. Added descriptions for properties `isEditable`, `isContinuous`, `isCollapsed` and `isExpanded`. Alphabetized entries (properties first, then instance method). Added notice for cases where getters will return `nil`: group layer `blendMode` and `opacity`. Emphasized that visibility, editability, collapsed/expanded properties are all local, not in respect to group hierarchy.