### PR TITLE
Image Get Pixel Out of Bounds

### DIFF
--- a/api/image.md
+++ b/api/image.md
@@ -151,6 +151,9 @@ In the following example, we show the differences between `getPixel()`,
 
 ![Coordinates example for getPixel](image/getpixel.gif)
 
+When the coordinates are out of bounds, returns `-1`. In Lua, this will be
+rendered as `4294967295`, `0xffffffff` in hexadecimal, i.e., opaque white.
+
 ## Image:drawImage()
 
 ```lua


### PR DESCRIPTION
Added explanation to `Image:getPixels` of return value when coordinates are out of bounds, e.g., `img:getPixel(-1, -1)`.