### PR TITLE
Remove `label` parameter from `dialog:separator`

### DIFF
--- a/api/dialog.md
+++ b/api/dialog.md
@@ -254,7 +254,6 @@ Creates a radio button. Arguments are the same as in [Dialog:button](#dialogbutt
 ```lua
 local dlg = Dialog()
 dlg:separator{ id=string,
-               label=string,
                text=string }
 ```
 


### PR DESCRIPTION
Parameters `label` doesn't seem to exist for `dialog:separator` according to [dialog_class.cpp](https://github.com/aseprite/aseprite/blob/main/src/app/script/dialog_class.cpp#L394).