### PR TITLE
😩 Fixed the app.site header behaving like a link

### DIFF
--- a/api/app.md
+++ b/api/app.md
@@ -2,7 +2,8 @@
 
 The `app` global namespace.
 
-## app.site
+## <a name="app.site">app.site</a>
+
 
 Active [site](site.md#site) (active image, layer, frame, sprite, etc.).
 


### PR DESCRIPTION
This took so long I won't admit how much. But, the header for app.site, despite being exactly like the other headings such as app.range or app.activeCel which don't show this behavior, app.site was one bad bad markdown monster.

The fix was not found on a forum or anything, though I tried - I actually used the <a name> html I often use to create special sidebar behavior and such.

Anyway, what was ## app.site is now:
## <a name="app.site">app.site</a>

Done. Fixed. This is the weirdest bug I've seen in markdown before.