### PR TITLE
Fix typo in Sprite::SaveAs()

### DIFF
--- a/api/sprite.md
+++ b/api/sprite.md
@@ -261,7 +261,7 @@ sprite:saveAs(filename)
 ```
 
 Saves the sprite to the given file and mark the sprite as saved so
-closing it doesn't will ask to save changes.
+closing it will not ask to save changes.
 
 ## Sprite:saveCopyAs()
 

--- a/api/sprite.md
+++ b/api/sprite.md
@@ -260,8 +260,8 @@ Crops the sprite to the given dimensions. See the
 sprite:saveAs(filename)
 ```
 
-Saves the sprite to the given file and mark the sprite as saved so
-closing it will not ask to save changes.
+Saves the sprite to the given file and marks the sprite as saved so
+closing it won't ask to save changes.
 
 ## Sprite:saveCopyAs()
 


### PR DESCRIPTION
Simple typo fix in Sprite::SaveAs()

Before:

> Saves the sprite to the given file and mark the sprite as saved so closing **_it doesn't will ask_** to save changes.

After:

> Saves the sprite to the given file and mark the sprite as saved so closing **_it will not ask_** to save changes.