### PR TITLE
Fix typo in api/image.md

### DIFF
--- a/api/image.md
+++ b/api/image.md
@@ -141,7 +141,7 @@ local numberOfBytesPerRow = image.rowStride
 ```
 
 Number of bytes for each row in the image. Each image has a total of
-`image.rowSide * image.height` bytes. It's useful if you are going to
+`image.rowStride * image.height` bytes. It's useful if you are going to
 get or set the [`Image.bytes`](#imagebytes) property manually.
 
 ## Image.bytesPerPixel


### PR DESCRIPTION
Fixed typo in the description of `Image.rowStride`

before:
>  Each image has a total of **`image.rowSide`** * `image.height` bytes

after:
>  Each image has a total of **`image.rowStride`** * `image.height` bytes.