### PR TITLE
fix link from #canvas -> #dialogcanvas in the Dialog api docs

### DIFF
--- a/api/dialog.md
+++ b/api/dialog.md
@@ -519,5 +519,5 @@ you don't need it you must explicitly set it to false.
 dlg:repaint()
 ```
 
-Will call `onpaint` event of all [canvases](#canvas) and update the
+Will call `onpaint` event of all [canvases](#dialogcanvas) and update the
 dialog pixels on the screen.


### PR DESCRIPTION
the internal link to the canvas section at the bottom of the `Dialog` page that I believe wants to link to the `Dialog:canvas` section, but my assumption is at some point the header link generation code may have changed 

Pointing it towards `#dialogcanvas` should properly make that link at the bottom of the page there work 