### PR TITLE
Added missing documentation for image.md and fliptype.md

### DIFF
--- a/api/fliptype.md
+++ b/api/fliptype.md
@@ -1,5 +1,12 @@
 # FlipType
 
+Type of flipping to be used in [image:flip](image.md#imageflip)
+
 ## FlipType.HORIZONTAL
+Defines a type of image flip that horizontally flips an image across the vertical axis.
 
 ## FlipType.VERTICAL
+Defines a type of image flip that vertically flips an image across the horizontal axis.
+
+## FlipType.DIAGONAL
+Defines a type of image flip that both vertically and horizontally flips an image across the diagonal axis.

--- a/api/image.md
+++ b/api/image.md
@@ -82,11 +82,15 @@ are modified).
 local w = image.width
 ```
 
+Returns the width of the image in pixels.
+
 ## Image.height
 
 ```lua
 local h = image.height
 ```
+
+Returns the height of the image in pixels.
 
 ## Image.bounds
 
@@ -337,3 +341,12 @@ local rectangle = image:shrinkBounds(refColor)
 Returns the shrunken bounds (a [rectangle](rectangle.md#rectangle)) of
 the image removing all the empty space of borders using the mask color
 or the given reference [color](color.md#color) in `refColor`.
+
+## Image:flip()
+
+```lua
+image:flip()
+image:flip(FlipType.VERTICAL)
+```
+
+Flips an image along an axis defined by a [FlipType](fliptype.md). Flips horizontally if [FlipType](fliptype.md) is not specified by default.


### PR DESCRIPTION
Added missing documentation/descriptions for a few functions/properties inside `image.md`:
- Image.width
- Image.height
- Image:flip()

Also added descriptions for each flip type defined in `fliptype.md`.