### PR TITLE
Explain that `local selection = sprite.selection` sets a reference

### DIFF
--- a/api/sprite.md
+++ b/api/sprite.md
@@ -88,6 +88,12 @@ Gets or sets the active sprite selection. This property is an instance
 of the [Selection class](selection.md#selection) to manipulate the set of
 selected pixels in the canvas.
 
+Keep in mind that `local selection = sprite.selection` will be a reference to the Sprite's selection, and will update when the Sprite's selection is changed or removed. To clone the selection, you can do the following instead:
+```lua
+local selection = Selection()
+selection:add(sprite.selection)
+```
+
 ## Sprite.filename
 
 ```lua


### PR DESCRIPTION
Added additional explanation that local selection = sprite.selection is a reference and will be updated, rather than a snapshot of the selection at the time of saving.

Added example on how to 'clone' the selection.

---------------------
I'm unfamiliar with the proper or preferred terms and general customs in regards to the API documentation, but I hope this works and is acceptable! Let me know if there are any changes that would be required!