### PR TITLE
Add `app.command.ToggleWorkspaceLayout` to the command documentation

### DIFF
--- a/api/app_command.md
+++ b/api/app_command.md
@@ -243,6 +243,8 @@ Executes the given command named `CommandName` with the specified parameters.
   * Toggles the visibility of the preview window
 * app.command.ToggleTimelineThumbnails
   * Toggles the timeline thumbnails preference
+* app.command.ToggleWorkspaceLayout
+  * Toggles the Workspace Layout UI. This command only opens or closes the workspace layout mode, and cannot be used to select a specific Layout.
 * app.command.UndoHistory
   * Shows the undo history window
 * app.command.Undo


### PR DESCRIPTION
As far as I could see it does not include any parameters. I'm unsure about the new UI markers and whether they would be required here.

I also just noticed this feature is still in beta, which might be why it wasn't in the documentation yet. But since I had already written it down anyway, might as well offer it up!