### PR TITLE
Add note on `Range.layers` sort order

### DIFF
--- a/api/app_command.md
+++ b/api/app_command.md
@@ -243,8 +243,6 @@ Executes the given command named `CommandName` with the specified parameters.
   * Toggles the visibility of the preview window
 * app.command.ToggleTimelineThumbnails
   * Toggles the timeline thumbnails preference
-* app.command.ToggleWorkspaceLayout
-  * Toggles the Workspace Layout UI. This command only opens or closes the workspace layout mode, and cannot be used to select a specific Layout.
 * app.command.UndoHistory
   * Shows the undo history window
 * app.command.Undo


### PR DESCRIPTION
Added a note on how Range.layers seems to be sorted, since it was surprising to find the order does not match the order layers are usually presented (such as in sprite.layers or layer.layers), and does not follow the next most logical assumption, that they are presented in order of selection.

I did some testing to determine that they are added in chronological order, but this could be coincidence if they are added in a random order instead.