### PR TITLE
Updated app.tool description to show that it is possible to set

### DIFF
--- a/api/app.md
+++ b/api/app.md
@@ -58,7 +58,7 @@ Returns the active [tag](tag.md#tag), which is the tag located at the
 
 ## app.tool
 
-Returns the active tool (a [Tool](tool.md#tool) object) selected in
+Gets or sets the active tool (a [Tool](tool.md#tool) object) selected in
 the [tool bar](https://www.aseprite.org/docs/workspace/).
 
 ## app.brush


### PR DESCRIPTION
Looking though the docs I noticed that the app.tool states it only returns the current tool in the toolbar but digging in to this more and finding out you can actually set the current tool using app.tool is quite helpful. Wanting to update this in the docs to reflect that it can actually set the value as well.

app.tool can be set using app.tool = "move" for instance.