### PR TITLE
Adjust `Dialog:button()` documentation

### DIFF
--- a/api/dialog.md
+++ b/api/dialog.md
@@ -161,12 +161,12 @@ Creates a button.
 Arguments (table fields):
 
 * `id`: Identifier for this button. [Dialog.data](#dialogdata) will contain a field
-  for each widget with and `id`.
-* `label`: Label at the left side of the control.
-* `text`: Text of the button.
+  for each widget with an `id`.
+* `label`: Text label on the left side of the control.
+* `text`: Text displayed on top of the button.
 * `selected`: True in case that you want to show the button checked by default.
 * `focus`: Focus this button by default or when the Enter key is pressed in an [text entry](#dialogentry) field.
-* `onclick`: Function to be called when the button is pressed.
+* `onclick`: Function to be called when the button is pressed. When ommitted, clicking the button will call [Dialog:close()](#dialogclose) instead.
 
 ## Dialog:check()
 

--- a/api/dialog.md
+++ b/api/dialog.md
@@ -166,7 +166,7 @@ Arguments (table fields):
 * `text`: Text displayed on top of the button.
 * `selected`: True in case that you want to show the button checked by default.
 * `focus`: Focus this button by default or when the Enter key is pressed in an [text entry](#dialogentry) field.
-* `onclick`: Function to be called when the button is pressed. When ommitted, clicking the button will call [Dialog:close()](#dialogclose) instead.
+* `onclick`: Function to be called when the button is pressed. When ommitted, clicking the button close the Dialog, as if [Dialog:close()](#dialogclose) was called.
 
 ## Dialog:check()
 

--- a/api/dialog.md
+++ b/api/dialog.md
@@ -166,7 +166,7 @@ Arguments (table fields):
 * `text`: Text displayed on top of the button.
 * `selected`: True in case that you want to show the button checked by default.
 * `focus`: Focus this button by default or when the Enter key is pressed in an [text entry](#dialogentry) field.
-* `onclick`: Function to be called when the button is pressed. When ommitted, clicking the button closes it's Dialog, as if [Dialog:close()](#dialogclose) was called.
+* `onclick`: Function to be called when the button is pressed. When omitted, clicking the button closes it's Dialog, as if [Dialog:close()](#dialogclose) was called.
 
 ## Dialog:check()
 

--- a/api/dialog.md
+++ b/api/dialog.md
@@ -166,7 +166,7 @@ Arguments (table fields):
 * `text`: Text displayed on top of the button.
 * `selected`: True in case that you want to show the button checked by default.
 * `focus`: Focus this button by default or when the Enter key is pressed in an [text entry](#dialogentry) field.
-* `onclick`: Function to be called when the button is pressed. When ommitted, clicking the button close the Dialog, as if [Dialog:close()](#dialogclose) was called.
+* `onclick`: Function to be called when the button is pressed. When ommitted, clicking the button closes it's Dialog, as if [Dialog:close()](#dialogclose) was called.
 
 ## Dialog:check()
 


### PR DESCRIPTION
Some small changes, most notably:

- Add explanation that the default behaviour of ommitting a `onclick` function  is to close the Dialog
- Slightly improve phrasing for `label` and `text` to differentiate between them better
- Fixed a spelling mistake