### PR TITLE
`Dialog:radio()` groups

### DIFF
--- a/api/dialog.md
+++ b/api/dialog.md
@@ -315,6 +315,8 @@ dlg:radio{ id=string,
 
 Creates a radio button. Arguments are the same as in [Dialog:button](#dialogbutton).
 
+Using `label` creates a new group.
+
 ## Dialog:separator()
 
 ```lua


### PR DESCRIPTION
It's possible to create radio button groups using the `label` property, but this information is not in the documentation. The only information I could find online was a single forum post ([How do I create a radio button group?](https://community.aseprite.org/t/how-do-i-create-a-radio-button-group/22151)).

I've updated the documentation to reflect that.